### PR TITLE
Fix dump container script

### DIFF
--- a/competition_environment/dump_my_container.sh
+++ b/competition_environment/dump_my_container.sh
@@ -1,20 +1,22 @@
 #!/bin/bash
 if [ -z $1 ] ; then
-  $1=1
-  echo "Defaulting to task $1"
+  TASK=1
+  echo "Defaulting to task $TASK"
+else
+  TASK=$1
 fi
-echo "Dumping for task $1"
+echo "Dumping for task $TASK"
 
 IMAGES=$(docker ps -a | tail -n +2 | sed 's/  */ /g')
-if echo $IMAGES | grep -v b_task_$1 ; then
-    echo "You don't have a b_task_$1 image present. Try starting the competition environment for task $1 first."
+if echo $IMAGES | grep -v b_task_$TASK ; then
+    echo "You don't have a b_task_$TASK image present. Try starting the competition environment for task $TASK first."
     exit 1
 fi
 
 
-echo "This script will dump the committed b_task_$1 image to a file. Be aware that you have to commit changes for this to work!"
+echo "This script will dump the committed b_task_$TASK image to a file. Be aware that you have to commit changes for this to work!"
 sleep 2
 
-echo "Dumping b_task_$1 to b_task_${1}.tgz now."
-docker image save b_task_$1 | gzip -c - > b_task_${1}.tgz
+echo "Dumping b_task_$TASK to b_task_${TASK}.tgz now."
+docker image save b_task_$TASK | gzip -c - > b_task_${TASK}.tgz
 echo "Please upload this file for competition purposes if your code is not public."

--- a/competition_environment/dump_my_container.sh
+++ b/competition_environment/dump_my_container.sh
@@ -18,5 +18,6 @@ echo "This script will dump the committed b_task_$TASK image to a file. Be aware
 sleep 2
 
 echo "Dumping b_task_$TASK to b_task_${TASK}.tgz now."
+echo "This may take several minutes."
 docker image save b_task_$TASK | gzip -c - > b_task_${TASK}.tgz
 echo "Please upload this file for competition purposes if your code is not public."


### PR DESCRIPTION
The `dump_my_container.sh` crashes if you are running it without the task as argument. This fixes defaulting to task 1 if no task was given as argument.